### PR TITLE
Move GITHUB_REPO_LINK constant to constants.ts

### DIFF
--- a/app/_components/repo-button.tsx
+++ b/app/_components/repo-button.tsx
@@ -2,10 +2,9 @@ import Link from "next/link";
 import Image from "next/image";
 
 import { Button } from "@/app/_components/ui/button";
+import { GITHUB_REPO_LINK } from "@/app/_lib/constants";
 
 export default function GitHubRepoButton() {
-  const GITHUB_REPO_LINK = "https://github.com/starlightroad/clippr";
-
   return (
     <Button type="button" size="icon" variant="outline" asChild>
       <Link href={GITHUB_REPO_LINK} target="_blank">

--- a/app/_lib/constants.ts
+++ b/app/_lib/constants.ts
@@ -22,3 +22,5 @@ export const ROUTES = {
   LOGIN: "/login",
   REGISTER: "/register",
 };
+
+export const GITHUB_REPO_LINK = "https://github.com/starlightroad/clippr";


### PR DESCRIPTION
## Description
This pull request improves project organization by moving the `GITHUB_REPO_LINK` constant to `constants.ts`.

## Changes
- Moved the `GITHUB_REPO_LINK` constant to `constants.ts`.
- Updated the repo button to use the new constant.