### PR TITLE
Rename HOME_METADATA to HOME_PAGE_METADATA for clarity

### DIFF
--- a/app/_lib/constants.ts
+++ b/app/_lib/constants.ts
@@ -1,4 +1,4 @@
-export const HOME_METADATA = {
+export const HOME_PAGE_METADATA = {
   TITLE: "Clippr",
   DESCRIPTION: "Your personal space to save and organize your favorite links.",
   KEYWORDS: [

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,15 +2,15 @@ import type { Metadata } from "next";
 
 import interFont from "@/app/_lib/font";
 import "./_styles/globals.css";
-import { HOME_METADATA } from "@/app/_lib/constants";
+import { HOME_PAGE_METADATA } from "@/app/_lib/constants";
 
 export const metadata: Metadata = {
   title: {
-    template: `%s - ${HOME_METADATA.TITLE}`,
-    default: HOME_METADATA.TITLE,
-    absolute: `${HOME_METADATA.TITLE} - ${HOME_METADATA.DESCRIPTION}`,
+    template: `%s - ${HOME_PAGE_METADATA.TITLE}`,
+    default: HOME_PAGE_METADATA.TITLE,
+    absolute: `${HOME_PAGE_METADATA.TITLE} - ${HOME_PAGE_METADATA.DESCRIPTION}`,
   },
-  description: HOME_METADATA.DESCRIPTION,
+  description: HOME_PAGE_METADATA.DESCRIPTION,
   keywords: [
     "bookmark manager",
     "save links",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { Heading1, Text } from "@/app/_components/ui/typography";
 import { Button } from "@/app/_components/ui/button";
 import Container from "@/app/_components/container";
 import Navbar from "@/app/_components/navbar";
-import { HOME_METADATA, ROUTES } from "@/app/_lib/constants";
+import { HOME_PAGE_METADATA, ROUTES } from "@/app/_lib/constants";
 
 export default function Home() {
   return (
@@ -15,7 +15,8 @@ export default function Home() {
           <div className="flex flex-col items-center text-center">
             <header>
               <Heading1>
-                {HOME_METADATA.TITLE} &ndash; {HOME_METADATA.DESCRIPTION}
+                {HOME_PAGE_METADATA.TITLE} &ndash;&nbsp;
+                {HOME_PAGE_METADATA.DESCRIPTION}
               </Heading1>
             </header>
             <Text className="max-w-xl text-xl font-medium text-muted-foreground">


### PR DESCRIPTION
## Description
This pull request renames the `HOME_METADATA` constant to `HOME_PAGE_METADATA` to improve clarity and maintain consistency in naming conventions. This change makes it more explicit that the metadata belongs to the home page.

## Changes
- Renamed `HOME_METADATA` to `HOME_PAGE_METADATA`.
- Updated all references to reflect the new change.