### PR TITLE
Enhance authentication: use signUpEmail, add middleware, and fix table schema

### DIFF
--- a/app/_db/schema/account.ts
+++ b/app/_db/schema/account.ts
@@ -17,8 +17,8 @@ export const account = pgTable("account", {
   refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
   scope: text("scope"),
   password: text("password"),
-  createdAt: timestamp("created_at", { mode: "string" }).defaultNow().notNull(),
-  updatedAt: timestamp("updated_at", { mode: "string" }).defaultNow().notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
 
 export const accountRelations = relations(account, ({ one }) => ({

--- a/app/_db/schema/session.ts
+++ b/app/_db/schema/session.ts
@@ -12,8 +12,8 @@ export const session = pgTable("session", {
   ipAddress: text("ip_address"),
   userAgent: text("user_agent"),
   expiresAt: timestamp("expires_at").notNull(),
-  createdAt: timestamp("created_at", { mode: "string" }).defaultNow().notNull(),
-  updatedAt: timestamp("updated_at", { mode: "string" }).defaultNow().notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
 
 export const sessionRelations = relations(session, ({ one }) => ({

--- a/app/_db/schema/user.ts
+++ b/app/_db/schema/user.ts
@@ -9,8 +9,8 @@ export const user = pgTable("user", {
   email: text("email").notNull().unique(),
   emailVerified: boolean("email_verified").notNull(),
   image: text("image"),
-  createdAt: timestamp("created_at", { mode: "string" }).defaultNow().notNull(),
-  updatedAt: timestamp("updated_at", { mode: "string" }).defaultNow().notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
 
 export const userRelations = relations(user, ({ one, many }) => ({

--- a/app/_db/schema/verification.ts
+++ b/app/_db/schema/verification.ts
@@ -4,7 +4,7 @@ export const verification = pgTable("verification", {
   id: text("id").primaryKey(),
   identifier: text("identifier").notNull(),
   value: text("value").notNull(),
-  expiresAt: timestamp("expires_at", { mode: "string" }).notNull(),
-  createdAt: timestamp("created_at", { mode: "string" }).defaultNow().notNull(),
-  updatedAt: timestamp("updated_at", { mode: "string" }).defaultNow().notNull(),
+  expiresAt: timestamp("expires_at").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });

--- a/app/_features/auth/index.ts
+++ b/app/_features/auth/index.ts
@@ -10,5 +10,7 @@ export {
   LoginFormSchema,
 } from "@/app/_features/auth/lib/definitions";
 
+export { auth } from "@/app/_features/auth/lib/auth";
+
 export { default as RegistrationForm } from "@/app/_features/auth/components/registration-form";
 export { default as LoginForm } from "@/app/_features/auth/components/login-form";

--- a/app/_features/auth/lib/auth.ts
+++ b/app/_features/auth/lib/auth.ts
@@ -1,5 +1,6 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { nextCookies } from "better-auth/next-js";
 
 import { db } from "@/app/_db/client";
 
@@ -10,4 +11,5 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
   },
+  plugins: [nextCookies()],
 });

--- a/app/_lib/constants.ts
+++ b/app/_lib/constants.ts
@@ -21,6 +21,7 @@ export const ROUTES = {
   HOME: "/",
   LOGIN: "/login",
   REGISTER: "/register",
+  DASHBOARD: "/d",
 };
 
 export const GITHUB_REPO_LINK = "https://github.com/starlightroad/clippr";
@@ -33,6 +34,8 @@ export const ERRORS = {
   AUTH: {
     INVALID_CREDENTIALS: "Invalid email or password.",
     UNAUTHORIZED: "You are not authorized to perform this action.",
+    USER_EXISTS: "User already exists.",
+    FAILED_TO_CREATE_USER: "Failed to create user.",
   },
   VALIDATION: {
     REQUIRED_FIELD: "This field is required.",

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSessionCookie } from "better-auth";
+
+export async function middleware(request: NextRequest) {
+  const sessionCookie = getSessionCookie(request);
+
+  if (!sessionCookie) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/d/:path*",
+};


### PR DESCRIPTION
## Description
This pull request enhances the registration process by updating the server action to use the `signUpEmail` method from `better-auth`. It also introduces a `middleware.ts` to restrict access to certain routes, redirecting unauthenticated users to the login page. Additionally, it resolves an issue in the database schema by removing `mode: "string"` from timestamp entries, which was causing an `ERR_INVALID_ARG_TYPE` error when using `better-auth`.

## Changes
- Updated the registration server action to use `signUpEmail` from `better-auth` for email-based sign-up.
- Added a `middleware.ts` file to enforce authentication for all routes under `/d`.
- Removed `mode: "string"` from all timestamp entries in the database schema.
- Fixed the `ERR_INVALID_ARG_TYPE` error caused by `better-auth`.